### PR TITLE
Throw an exception if a specified folder to iterate over doesn't exist

### DIFF
--- a/src/main/java/com/soebes/maven/plugins/iterator/AbstractIteratorMojo.java
+++ b/src/main/java/com/soebes/maven/plugins/iterator/AbstractIteratorMojo.java
@@ -137,12 +137,17 @@ public abstract class AbstractIteratorMojo
     }
 
     protected List<String> getFolders()
+        throws MojoExecutionException
     {
         IOFileFilter folders = FileFilterUtils.and( HiddenFileFilter.VISIBLE, DirectoryFileFilter.DIRECTORY );
         IOFileFilter makeSVNAware = FileFilterUtils.makeSVNAware( folders );
         IOFileFilter makeCVSAware = FileFilterUtils.makeCVSAware( makeSVNAware );
 
         String[] list = folder.list( makeCVSAware );
+        if (list == null) {
+            throw new MojoExecutionException( "The specified folder doesn't exist: " + folder );
+        }
+
         List<File> listOfDirectories = new ArrayList<File>();
         for ( String item : list )
         {

--- a/src/test/java/com/soebes/maven/plugins/iterator/AbstractIteratorMojoTest.java
+++ b/src/test/java/com/soebes/maven/plugins/iterator/AbstractIteratorMojoTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.util.List;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -47,6 +48,7 @@ public class AbstractIteratorMojoTest
 
     @Test
     public void shouldReturnTheSubfoldersInOrder()
+        throws MojoExecutionException
     {
         when( mock.getSortOrder() ).thenReturn( "NAME_COMPARATOR" );
         List<String> folders = mock.getFolders();
@@ -55,9 +57,19 @@ public class AbstractIteratorMojoTest
 
     @Test
     public void shouldReturnTheSubfoldersInReversOrder()
+        throws MojoExecutionException
     {
         when( mock.getSortOrder() ).thenReturn( "NAME_REVERSE" );
         List<String> folders = mock.getFolders();
         assertThat( folders ).containsSequence( "test", "site", "main", "it" );
     }
+
+    @Test(expectedExceptions = MojoExecutionException.class)
+    public void shouldThrowExceptionOnNonExistentFolder()
+        throws MojoExecutionException
+    {
+        mock.setFolder( new File( "nonexistent" ) );
+        mock.getFolders();
+    }
+
 }


### PR DESCRIPTION
Currently, the `iterator` goal throws a `NullPointerException` if the configured `<folder>` doesn't exist, which is not very descriptive. This commit adds a specific error message to understand quicker the problem.

Stacktrace before:
>[ERROR] Failed to execute goal com.soebes.maven.plugins:iterator-maven-plugin:0.4-SNAPSHOT:iterator (iterate) on project test: Execution iterate of goal com.soebes.maven.plugins:iterator-maven-plugin:0.4-SNAPSHOT:iterator failed. NullPointerException -> [Help 1]

Stacktrace after:
>[ERROR] Failed to execute goal com.soebes.maven.plugins:iterator-maven-plugin:0.4-SNAPSHOT:iterator (iterate) on project test: The specified folder doesn't exist: `<something>\test\nonexistent` -> [Help 1]
