### PR TITLE
Prefer local configuration to default configurations

### DIFF
--- a/src/main/java/com/soebes/maven/plugins/iterator/IteratorMojo.java
+++ b/src/main/java/com/soebes/maven/plugins/iterator/IteratorMojo.java
@@ -360,7 +360,7 @@ public class IteratorMojo
         if ( executePlugin.getConfiguration() != null )
         {
             Xpp3Dom x = (Xpp3Dom) executePlugin.getConfiguration();
-            resultConfiguration = Xpp3DomUtils.mergeXpp3Dom( x, toXpp3Dom( pluginExecutor.getConfiguration() ) );
+            resultConfiguration = Xpp3DomUtils.mergeXpp3Dom( toXpp3Dom( pluginExecutor.getConfiguration() ), x );
 
             getLog().debug( "ConfigurationExecutePlugin: " + executePlugin.getConfiguration().toString() );
 


### PR DESCRIPTION
According to https://maven.apache.org/shared/maven-shared-utils/apidocs/org/apache/maven/shared/utils/xml/Xpp3DomUtils.html#mergeXpp3Dom(org.apache.maven.shared.utils.xml.Xpp3Dom,%20org.apache.maven.shared.utils.xml.Xpp3Dom) the first parameter is the dominant one. We should prefer the pluginExecutor.getConfiguration specified in the user's pom.xml over the default ones from the plugin.